### PR TITLE
Fix np.int

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 scipy
 pandas
-numpy
+numpy<=1.19.5
 pybedtools
-idr<=1.19.5
+idr
 deeptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ scipy
 pandas
 numpy
 pybedtools
-idr<=1.19
+idr<=1.19.5
 deeptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ scipy
 pandas
 numpy
 pybedtools
-idr
+idr<=1.19
 deeptools


### PR DESCRIPTION
`idr` returned an error because it is using a deprecated `numpy` command `np.int`. Restricted the version of `numpy` before the deprecation (<1.20).