### PR TITLE
Fix: Chromosome names are consistently treated as strings

### DIFF
--- a/peaklib/peaklib.py
+++ b/peaklib/peaklib.py
@@ -37,6 +37,7 @@ class PeakCaller(object):
         self.starts_by_chrom = {}
         self.chroms = []
 
+        self.df["chrom"] = self.df["chrom"].astype(str)
         for chrom in sorted(self.df["chrom"].unique()):
 
             idx = self.df["chrom"] == chrom


### PR DESCRIPTION
Issue: Sorting mixed-type chromosomes ('1', 'chr1', 1) leads to TypeError: '<' not supported between 'str' and 'int' instances.
Fix: Converts self.df["chrom"] to strings using .astype(str).